### PR TITLE
Add demo booking and info pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,15 @@
+import { CONTACT_EMAIL } from '../../lib/config';
+
+export default function About() {
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-6">
+      <h1 className="text-4xl font-semibold">About Us</h1>
+      <p>
+        Agentsicify delivers premium AI agentic solutions crafted to automate workflows and accelerate growth. Our expert team builds reliable infrastructures and intelligent agents to empower businesses worldwide.
+      </p>
+      <p>
+        Interested in partnering with us? Reach out at <a className="text-blue-600 underline" href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+      </p>
+    </div>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { useState } from 'react';
+import { CONTACT_EMAIL } from '../../lib/config';
+
+export default function Contact() {
+  const [form, setForm] = useState({ name: '', email: '', message: '' });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const mailto = `mailto:${CONTACT_EMAIL}?subject=Contact%20Request&body=Name:%20${encodeURIComponent(form.name)}%0AEmail:%20${encodeURIComponent(form.email)}%0A%0A${encodeURIComponent(form.message)}`;
+    window.location.href = mailto;
+  };
+
+  return (
+    <div className="max-w-lg mx-auto p-6 space-y-6">
+      <h1 className="text-4xl font-semibold">Contact Us</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input type="text" name="name" placeholder="Name" required className="w-full border p-2" value={form.name} onChange={handleChange}/>
+        <input type="email" name="email" placeholder="Email" required className="w-full border p-2" value={form.email} onChange={handleChange}/>
+        <textarea name="message" placeholder="Message" required className="w-full border p-2" rows={4} value={form.message} onChange={handleChange}></textarea>
+        <button type="submit" className="bg-foreground text-background px-4 py-2">Send</button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useState } from 'react';
+import { CONTACT_EMAIL } from '../../lib/config';
+
+export default function Demo() {
+  const [form, setForm] = useState({ name: '', business: '', email: '', date: '' });
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const body = `Name: ${form.name}\nBusiness: ${form.business}\nEmail: ${form.email}\nPreferred date: ${form.date}`;
+    const mailto = `mailto:${CONTACT_EMAIL}?subject=Demo%20Request&body=${encodeURIComponent(body)}`;
+    window.location.href = mailto;
+  };
+
+  return (
+    <div className="max-w-lg mx-auto p-6 space-y-6">
+      <h1 className="text-4xl font-semibold">Book a Demo</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input type="text" name="name" placeholder="Name" required className="w-full border p-2" value={form.name} onChange={handleChange}/>
+        <input type="text" name="business" placeholder="Business" required className="w-full border p-2" value={form.business} onChange={handleChange}/>
+        <input type="email" name="email" placeholder="Email" required className="w-full border p-2" value={form.email} onChange={handleChange}/>
+        <input type="datetime-local" name="date" className="w-full border p-2" value={form.date} onChange={handleChange}/>
+        <button type="submit" className="bg-foreground text-background px-4 py-2">Submit</button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import Navbar from "../components/Navbar";
 
 export const metadata: Metadata = {
   title: "Agentsicify - AI Agentic Solutions",
@@ -13,9 +14,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="antialiased">
-        {children}
-      </body>
+      <body className="antialiased flex flex-col min-h-screen">
+        <Navbar />
+        <main className="flex-1">{children}</main>
+        </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,27 +9,27 @@ export default function Home() {
           AI agentic solutions that help modern businesses automate workflows and unlock growth.
         </p>
         <Link
-          href="#contact"
+          href="/demo"
           className="rounded-full bg-foreground text-background px-6 py-3 text-sm font-medium hover:bg-[#383838] dark:hover:bg-[#ccc] transition-colors"
         >
-          Get Started
+          Book a Demo
         </Link>
       </main>
       <section className="grid gap-8 py-16 px-6 max-w-5xl mx-auto md:grid-cols-3 text-center">
         <div>
-          <h3 className="mb-2 text-xl font-medium">Automation</h3>
+          <h3 className="mb-2 text-xl font-medium">⚙️ Automation</h3>
           <p className="text-gray-600 dark:text-gray-400">Streamline repetitive tasks with custom AI agents.</p>
         </div>
         <div>
-          <h3 className="mb-2 text-xl font-medium">Insights</h3>
+          <h3 className="mb-2 text-xl font-medium">📊 Insights</h3>
           <p className="text-gray-600 dark:text-gray-400">Analyze data in real time to drive better decisions.</p>
         </div>
         <div>
-          <h3 className="mb-2 text-xl font-medium">Growth</h3>
+          <h3 className="mb-2 text-xl font-medium">🚀 Growth</h3>
           <p className="text-gray-600 dark:text-gray-400">Scale your business with intelligent automations.</p>
         </div>
       </section>
-      <footer id="contact" className="py-6 text-center text-sm text-gray-500">
+      <footer className="py-6 text-center text-sm text-gray-500">
         © {new Date().getFullYear()} Agentsicify
       </footer>
     </div>

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -1,0 +1,14 @@
+export default function Services() {
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <h1 className="text-4xl font-semibold mb-4">Our Services</h1>
+      <ul className="space-y-4 list-disc list-inside">
+        <li>HR agents that classify and shortlist candidates for your open roles.</li>
+        <li>AI-powered headhunting to attract top talent.</li>
+        <li>Agents that monitor employee performance and provide actionable insights.</li>
+        <li>Customer-facing AI agents that handle support and business inquiries.</li>
+        <li>Custom MCP (Multi-Agent Collaboration Platform) infrastructure development for partners.</li>
+      </ul>
+    </div>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+export default function Navbar() {
+  return (
+    <header className="px-6 py-4 border-b border-gray-200 dark:border-gray-800 flex items-center justify-between">
+      <Link href="/" className="font-semibold text-lg">Agentsicify</Link>
+      <nav className="flex gap-4 text-sm">
+        <Link href="/services" className="hover:underline">Services</Link>
+        <Link href="/about" className="hover:underline">About</Link>
+        <Link href="/contact" className="hover:underline">Contact</Link>
+        <Link href="/demo" className="rounded-full bg-foreground text-background px-4 py-2 hover:bg-[#383838] dark:hover:bg-[#ccc] transition-colors">Book a Demo</Link>
+      </nav>
+    </header>
+  );
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,1 @@
+export const CONTACT_EMAIL = process.env.NEXT_PUBLIC_CONTACT_EMAIL || 'mostafa0as3d@gmail.com';


### PR DESCRIPTION
## Summary
- add site navbar and email config helper
- implement about, contact, services, and demo booking pages
- update homepage to link to demo booking page and add icons

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684579dc7078832f8fb3b27e755036a9